### PR TITLE
Update eslint-config-fusion@0.2.0 and apply import fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.0.4",
     "eslint": "^4.11.0",
-    "eslint-config-fusion": "^0.1.2",
+    "eslint-config-fusion": "^0.2.0",
     "eslint-plugin-cup": "^1.0.0",
     "eslint-plugin-flowtype": "^2.39.1",
+    "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
     "flow-bin": "^0.59.0",
@@ -47,6 +48,7 @@
   },
   "peerDependencies": {
     "fusion-core": "^0.2.3",
+    "prop-types": "^15.6.0",
     "react": "14.x - 16.x"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 // @flow
-export {withFontLoading} from './with-font-loading';
-export {FontPlugin} from './plugin';
+import withFontLoading from './with-font-loading';
+import FontPlugin from './plugin';
+
+export {withFontLoading, FontPlugin};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
 // @flow
-import withFontLoading from './with-font-loading';
-import FontPlugin from './plugin';
-
-export {withFontLoading, FontPlugin};
+export {default as withFontLoading} from './with-font-loading';
+export {default as FontPlugin} from './plugin';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,7 +11,7 @@ import generateFontFaces from './generate-font-faces';
 const fontsToPreload = {};
 let fallbackLookup;
 
-export const FontPlugin = configObject => {
+const FontPlugin = configObject => {
   const {fonts, preloadDepth} = configObject;
 
   fallbackLookup = generateFallbackMap(fonts, preloadDepth);
@@ -38,6 +38,7 @@ export const FontPlugin = configObject => {
     }
   };
 };
+export default FontPlugin;
 
 function getFontDetails(name) {
   const {name: fallbackName, styles = {}} = fallbackLookup[name] || {};

--- a/src/with-font-loading.js
+++ b/src/with-font-loading.js
@@ -17,7 +17,7 @@ withFontLoading('Lato-Bold')(styled('div', props => props.fontStyles));
 All requested fonts should be defined in src/fonts/fontConfig.js
 */
 
-export const withFontLoading = fontName => {
+const withFontLoading = fontName => {
   return OriginalComponent => {
     class WithFontLoading extends Component {
       constructor(props, context) {
@@ -51,3 +51,5 @@ export const withFontLoading = fontName => {
     return WithFontLoading;
   };
 };
+
+export default withFontLoading;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,7 +1148,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1358,6 +1358,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 content-disposition@~0.5.0:
   version "0.5.2"
@@ -1625,6 +1629,13 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 doctrine@^2.0.0, doctrine@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
@@ -1891,11 +1902,11 @@ eslint-config-cup@^1.0.0-rc.4:
   version "1.0.0"
   resolved "https://registry.npmjs.org/eslint-config-cup/-/eslint-config-cup-1.0.0.tgz#0fcdb787fe254fc9458ec5258143cb0d47052896"
 
-eslint-config-fusion@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/eslint-config-fusion/-/eslint-config-fusion-0.1.2.tgz#cf380a75090d3cee0c9c086165b86fd60619e0aa"
+eslint-config-fusion@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/eslint-config-fusion/-/eslint-config-fusion-0.2.0.tgz#9a219e6a8d225d1fd59878455dbf1b8d3b8c0c34"
   dependencies:
-    eslint-config-uber-universal-stage-3 "^1.0.0-rc.6"
+    eslint-config-uber-universal-stage-3 "^1.0.0-rc.7"
 
 eslint-config-prettier@^2.0.0:
   version "2.9.0"
@@ -1915,12 +1926,26 @@ eslint-config-uber-base@^1.0.0-rc.7:
   dependencies:
     eslint-config-prettier "^2.0.0"
 
-eslint-config-uber-universal-stage-3@^1.0.0-rc.6:
+eslint-config-uber-universal-stage-3@^1.0.0-rc.7:
   version "1.0.0-rc.7"
   resolved "https://registry.npmjs.org/eslint-config-uber-universal-stage-3/-/eslint-config-uber-universal-stage-3-1.0.0-rc.7.tgz#bd4de38543d3c27cf48d82925bfccb5efb5b541f"
   dependencies:
     eslint-config-cup "^1.0.0-rc.4"
     eslint-config-uber-base-stage-3 "^1.0.0-rc.7"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
+  dependencies:
+    debug "^2.6.8"
+    resolve "^1.2.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
 
 eslint-plugin-cup@^1.0.0:
   version "1.0.0"
@@ -1933,6 +1958,21 @@ eslint-plugin-flowtype@^2.39.1:
   resolved "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.40.1.tgz#f78a8e6a4cc6da831dd541eb61e803ff0279b796"
   dependencies:
     lodash "^4.15.0"
+
+eslint-plugin-import@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
 
 eslint-plugin-prettier@^2.3.1:
   version "2.3.1"
@@ -3190,6 +3230,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -3364,7 +3408,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4295,7 +4339,7 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.3.2:
+resolve@^1.2.0, resolve@^1.3.2:
   version "1.5.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION
This linter upgrade will include the import linter which will avoid issues like #6. Also including some work to get around the linter, such as preferring default exports,