### PR TITLE
Migrate to `fusion-core@0.3.0-5` with dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ const FancyLink1 = withFontLoading('Lato-Bold'.(
 
 This will lazy-load `Lato-Bold` and meanwhile assign a fallback font and styling to the element via `props.fontStyles`.
 
+---
+
 ### Utils
 
 #### font-loader.js

--- a/README.md
+++ b/README.md
@@ -6,15 +6,51 @@ Provides :
 1. A fusion plugin that generates @font-faces and preloads fallback fonts based on app-level font configuration.
 2. A Higher Order Component for loading custom web fonts (and associated utils). During font loading, this HOC temporarily swaps the element to a well-matched fallback font, avoiding FOIT and FOUT. See https://www.zachleat.com/web/comprehensive-webfonts/#critical-foft-preload for more on this.
 
-## Installation
+---
+
+### Installation
 
 ```
 yarn add fusion-plugin-font-loading
 ```
 
-## Usage
+---
 
-### Configuration
+### Example
+
+```js
+// src/main.js
+import App rom 'fusion-core';
+import {
+  FontPlugin as FontLoaderReact,
+  FontLoaderReactConfigToken
+} from 'fusion-plugin-font-loader-react';
+
+export default () => {
+  const app = new App(<div></div>);
+  // ...
+  app.register(FontLoaderReactConfigToken, {/*some config*/});
+  app.register(FontLoaderReact);
+  // ...
+  return app;
+}
+
+// src/some-component.js
+import {withFontLoading} from 'fusion-plugin-font-loader-react';
+
+const FancyLink1 = withFontLoading('Lato-Bold'.(
+  styled('a', props => ({
+    ':hover': {fontSize: `${props.answer}px`}.
+    ...props.fontStyles,
+  }))
+);
+```
+
+---
+
+### Usage
+
+#### Configuration
 Consuming apps should define a `font-config.js` which a) provides data for @font-face generation, b) is used to derive the fallback font and styles that will be used by the `with-font-loading.js` HOC.
 
 _Sample \<app\>/src/font-config.js file_
@@ -55,7 +91,7 @@ export const fonts = {
 };
 ```
 
-#### @font-face generation
+##### @font-face generation
 
 Based on the example configuration file above the following @font-face would be generated in <head>
 
@@ -65,7 +101,7 @@ Based on the example configuration file above the following @font-face would be 
 @font-face {font-family: "Lato-Thin"; src: url("/_static/03b64805a8cd2d53fadc5814445c2fb5.woff2") format("woff2");}
 ```
 
-#### font loading
+##### font loading
 
 1. An in-memory font fallback tree is generated at runtime based on the defintitions provided in `font-config.js`
 2. Fallbacks at and above the specified `preloadDepth` will be preloaded/prefetched on page load
@@ -92,7 +128,7 @@ If `preloadDepth` were 0 then every font would be preloaded, and there would be 
 
 If `preloadDepth` were 2 then the only fallback font would be Helvetica, and since Helvetica is a system font, no custom fonts would be preloaded.
 
-### Higher Order Component
+#### Higher Order Component
 
 This repo also supplies a `with-font-loading.js` Higher Order Component which is used to:
 1. Load a specified font
@@ -110,9 +146,9 @@ const FancyLink1 = withFontLoading('Lato-Bold'.(
 
 This will lazy-load `Lato-Bold` and meanwhile assign a fallback font and styling to the element via `props.fontStyles`.
 
-## Utils
+### Utils
 
-### font-loader.js
+#### font-loader.js
 
 Promise used by `with-font-loading.js` HOC to dynamically load specified font; calls `resolve` when load is complete.
 

--- a/package.json
+++ b/package.json
@@ -5,49 +5,46 @@
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-font-loading",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
-  "main": "./dist/node.cjs.js",
-  "module": "./dist/node.es.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.es.js",
   "browser": {
-    "./dist/node.cjs.js": "./dist/browser.es5.cjs.js",
-    "./dist/node.es.js": "./dist/browser.es5.es.js"
+    "./dist/index.js": "./dist/browser.es5.js",
+    "./dist/index.es.js": "./dist/browser.es5.es.js"
   },
   "es2015": {
-    "./dist/browser.es5.cjs.js": "./dist/browser.es2015.cjs.js",
     "./dist/browser.es5.es.js": "./dist/browser.es2015.es.js"
   },
   "es2017": {
-    "./dist/browser.es5.cjs.js": "./dist/browser.es2017.cjs.js",
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
-    "./dist/browser.es2015.cjs.js": "./dist/browser.es2017.cjs.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
-  "dependencies": {},
   "devDependencies": {
-    "@babel/preset-react": "^7.0.0-beta.32",
-    "babel-eslint": "^8.0.2",
-    "create-universal-package": "^2.1.1",
-    "enzyme": "^3.1.1",
-    "enzyme-adapter-react-16": "^1.0.4",
-    "eslint": "^4.11.0",
-    "eslint-config-fusion": "^0.2.0",
+    "@babel/preset-react": "^7.0.0-beta.38",
+    "babel-eslint": "^8.2.1",
+    "create-universal-package": "^3.2.6",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "eslint": "^4.16.0",
+    "eslint-config-fusion": "^0.2.1",
     "eslint-plugin-cup": "^1.0.0",
-    "eslint-plugin-flowtype": "^2.39.1",
+    "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-prettier": "^2.3.1",
-    "eslint-plugin-react": "^7.4.0",
-    "flow-bin": "^0.59.0",
-    "fusion-core": "^0.2.3",
-    "nyc": "^11.3.0",
-    "prettier": "1.8.2",
-    "react": "^16.1.1",
-    "react-dom": "^16.1.1",
+    "eslint-plugin-prettier": "^2.5.0",
+    "eslint-plugin-react": "^7.6.0",
+    "flow-bin": "^0.64.0",
+    "fusion-core": "^0.2.8",
+    "nyc": "^11.4.1",
+    "prettier": "1.10.2",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "tape-cup": "^4.7.1",
-    "unitest": "^1.1.0"
+    "unitest": "^2.1.1"
   },
   "peerDependencies": {
-    "fusion-core": "^0.2.3",
+    "fusion-core": "^0.2.8",
     "prop-types": "^15.6.0",
     "react": "14.x - 16.x"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-prettier": "^2.5.0",
     "eslint-plugin-react": "^7.6.0",
     "flow-bin": "^0.64.0",
-    "fusion-core": "^0.2.8",
+    "fusion-core": "^0.3.0-5",
     "nyc": "^11.4.1",
     "prettier": "1.10.2",
     "react": "^16.2.0",
@@ -44,7 +44,7 @@
     "unitest": "^2.1.1"
   },
   "peerDependencies": {
-    "fusion-core": "^0.2.8",
+    "fusion-core": "^0.3.0-5",
     "prop-types": "^15.6.0",
     "react": "14.x - 16.x"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react": "^7.6.0",
     "flow-bin": "^0.64.0",
     "fusion-core": "^0.3.0-5",
+    "fusion-tokens": "0.0.5",
     "nyc": "^11.4.1",
     "prettier": "1.10.2",
     "react": "^16.2.0",
@@ -45,6 +46,7 @@
   },
   "peerDependencies": {
     "fusion-core": "^0.3.0-5",
+    "fusion-tokens": "0.0.5",
     "prop-types": "^15.6.0",
     "react": "14.x - 16.x"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "flow-bin": "^0.64.0",
     "fusion-core": "^0.3.0-5",
     "fusion-tokens": "0.0.5",
+    "fusion-test-utils": "^0.4.1",
     "nyc": "^11.4.1",
     "prettier": "1.10.2",
     "react": "^16.2.0",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,13 +1,15 @@
 import tape from 'tape-cup';
-import generateFallbackMap from '../generate-fallback-map';
-import generateFontFaces from '../generate-font-faces';
-import generatePreloadLinks from '../generate-preload-links';
-import {fonts} from './fixtures/static/font-config';
+
+import {fonts as mockFonts} from './fixtures/static/font-config';
 import {
   fallbackLookup as expectedFallbackLookup,
   fontFaces as expectedFontFaces,
   preloadLinks as expectedPreloadLinks,
 } from './fixtures/expected';
+
+import generateFallbackMap from '../generate-fallback-map';
+import generateFontFaces from '../generate-font-faces';
+import generatePreloadLinks from '../generate-preload-links';
 
 tape('generateFallbackMap', t => {
   t.equal(
@@ -15,9 +17,9 @@ tape('generateFallbackMap', t => {
     'function',
     'exports a generateFallbackMap function'
   );
-  t.deepEqual(generateFallbackMap(fonts, 0), expectedFallbackLookup.depth0);
-  t.deepEqual(generateFallbackMap(fonts, 1), expectedFallbackLookup.depth1);
-  t.deepEqual(generateFallbackMap(fonts, 2), expectedFallbackLookup.depth2);
+  t.deepEqual(generateFallbackMap(mockFonts, 0), expectedFallbackLookup.depth0);
+  t.deepEqual(generateFallbackMap(mockFonts, 1), expectedFallbackLookup.depth1);
+  t.deepEqual(generateFallbackMap(mockFonts, 2), expectedFallbackLookup.depth2);
   t.end();
 });
 
@@ -27,7 +29,7 @@ tape('generateFontFaces', t => {
     'function',
     'exports a generateFontFaces function'
   );
-  t.equal(generateFontFaces(fonts), expectedFontFaces);
+  t.equal(generateFontFaces(mockFonts), expectedFontFaces);
   t.end();
 });
 
@@ -38,7 +40,7 @@ tape('generatePreloadLinks', t => {
     'exports a generatePreloadLinks function'
   );
   t.equal(
-    generatePreloadLinks({'Lato-Regular': true}, fonts),
+    generatePreloadLinks({'Lato-Regular': true}, mockFonts),
     expectedPreloadLinks
   );
   t.end();

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -1,0 +1,37 @@
+import tape from 'tape-cup';
+
+import App from 'fusion-core';
+import {getSimulator} from 'fusion-test-utils';
+
+import {
+  fonts as mockFonts,
+  preloadDepth as mockPreloadDepth,
+} from './fixtures/static/font-config';
+
+import {FontPlugin as FontLoaderReactPlugin} from '../index';
+import {FontLoaderReactToken, FontLoaderReactConfigToken} from '../tokens';
+
+tape('plugin - middleware modifies head as expected', t => {
+  const mockConfig = {
+    fonts: mockFonts,
+    preloadDepth: mockPreloadDepth,
+  };
+
+  const app = new App('content', el => el);
+  app.middleware(async (ctx, next) => {
+    await next();
+    t.true(ctx.body.head.length > 0, 'head was modified by plugin');
+  });
+  app.register(FontLoaderReactToken, FontLoaderReactPlugin);
+  app.register(FontLoaderReactConfigToken, mockConfig);
+  app.middleware((ctx, next) => {
+    ctx.body = {
+      head: [],
+    };
+    return next();
+  });
+
+  getSimulator(app).render('/');
+
+  t.end();
+});

--- a/src/__tests__/plugin.node.js
+++ b/src/__tests__/plugin.node.js
@@ -8,8 +8,14 @@ import {
   preloadDepth as mockPreloadDepth,
 } from './fixtures/static/font-config';
 
-import {FontPlugin as FontLoaderReactPlugin} from '../index';
+import FontLoaderReactPlugin from '../index';
 import {FontLoaderReactToken, FontLoaderReactConfigToken} from '../tokens';
+
+tape('exported as expected', t => {
+  t.ok(FontLoaderReactPlugin, 'plugin defined as expected');
+  t.equal(typeof FontLoaderReactPlugin, 'object', 'plugin is an object');
+  t.end();
+});
 
 tape('plugin - middleware modifies head as expected', t => {
   const mockConfig = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 // @flow
-export {default as withFontLoading} from './with-font-loading';
-export {default} from './plugin';
 
-export {FontLoaderReactToken, FontLoaderReactConfigToken} from './tokens';
+import withFontLoading from './with-font-loading';
+import FontLoaderReactPlugin from './plugin';
+import {FontLoaderReactToken, FontLoaderReactConfigToken} from './tokens';
+
+export default FontLoaderReactPlugin;
+export {withFontLoading, FontLoaderReactToken, FontLoaderReactConfigToken};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
 export {default as withFontLoading} from './with-font-loading';
-export {default as FontPlugin} from './plugin';
+export {default} from './plugin';
 
 export {FontLoaderReactToken, FontLoaderReactConfigToken} from './tokens';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 // @flow
 export {default as withFontLoading} from './with-font-loading';
 export {default as FontPlugin} from './plugin';
+
+export {FontLoaderReactToken, FontLoaderReactConfigToken} from './tokens';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,7 +29,7 @@ const plugin = createPlugin({
         );
         return next().then(() => {
           if (__NODE__) {
-            ctx.body.head.push(html`<style>`);
+            ctx.body.head.push(html`style<>`);
             ctx.body.head.push(dangerouslySetHTML(generateFontFaces(fonts)));
             ctx.body.head.push(html`</style>`);
             ctx.body.head.push(

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,45 +1,51 @@
 /* eslint-env node */
 import React from 'react';
 
-import {html, dangerouslySetHTML} from 'fusion-core';
+import {createPlugin, html, dangerouslySetHTML} from 'fusion-core';
 import FontProvider from './provider';
 import generateFallbackMap from './generate-fallback-map';
 import generatePreloadLinks from './generate-preload-links';
 import generateFontFaces from './generate-font-faces';
+import {FontLoaderReactConfigToken as ConfigToken} from './tokens';
 
 // keys are the actual fonts to preload (based on usage on the page), values are always true
 const fontsToPreload = {};
 let fallbackLookup;
 
-const FontPlugin = configObject => {
-  const {fonts, preloadDepth} = configObject;
+const plugin = createPlugin({
+  deps: {
+    config: ConfigToken,
+  },
+  middleware: ({config}) => {
+    const {fonts, preloadDepth} = config;
+    fallbackLookup = generateFallbackMap(fonts, preloadDepth);
 
-  fallbackLookup = generateFallbackMap(fonts, preloadDepth);
+    return (ctx, next) => {
+      if (ctx.element) {
+        ctx.element = (
+          <FontProvider getFontDetails={getFontDetails}>
+            {ctx.element}
+          </FontProvider>
+        );
+        return next().then(() => {
+          if (__NODE__) {
+            ctx.body.head.push(html`<style>`);
+            ctx.body.head.push(dangerouslySetHTML(generateFontFaces(fonts)));
+            ctx.body.head.push(html`</style>`);
+            ctx.body.head.push(
+              dangerouslySetHTML(generatePreloadLinks(fontsToPreload, fonts))
+            );
+          }
+        });
+      } else {
+        return next();
+      }
+    };
+  },
+});
+export default plugin;
 
-  return (ctx, next) => {
-    if (ctx.element) {
-      ctx.element = (
-        <FontProvider getFontDetails={getFontDetails}>
-          {ctx.element}
-        </FontProvider>
-      );
-      return next().then(() => {
-        if (__NODE__) {
-          ctx.body.head.push(html`<style>`);
-          ctx.body.head.push(dangerouslySetHTML(generateFontFaces(fonts)));
-          ctx.body.head.push(html`</style>`);
-          ctx.body.head.push(
-            dangerouslySetHTML(generatePreloadLinks(fontsToPreload, fonts))
-          );
-        }
-      });
-    } else {
-      return next();
-    }
-  };
-};
-export default FontPlugin;
-
+/* Helper functions */
 function getFontDetails(name) {
   const {name: fallbackName, styles = {}} = fallbackLookup[name] || {};
   const result = {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,7 +29,7 @@ const plugin = createPlugin({
         );
         return next().then(() => {
           if (__NODE__) {
-            ctx.body.head.push(html`style<>`);
+            ctx.body.head.push(html`<style>`);
             ctx.body.head.push(dangerouslySetHTML(generateFontFaces(fonts)));
             ctx.body.head.push(html`</style>`);
             ctx.body.head.push(

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,7 @@
+import {createToken} from 'fusion-tokens';
+
+export const FontLoaderReactToken = createToken('FontLoaderReactToken');
+
+export const FontLoaderReactConfigToken = createToken(
+  'FontLoaderReactConfigToken'
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,25 +10,33 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/code-frame@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.34.tgz#e8e81e37ee65a35cedc8a22a11a51d792bdc651c"
+"@babel/code-frame@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2fcode-frame/-/code-frame-7.0.0-beta.36.tgz#2349d7ec04b3a06945ae173280ef8579b63728e4"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/core@^7.0.0-beta.31":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.34.tgz#576863223bcb4d003e9450b2a4c5076a626be966"
+"@babel/code-frame@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fcode-frame/-/code-frame-7.0.0-beta.38.tgz#c0af5930617e55e050336838e3a3670983b0b2b2"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.34"
-    "@babel/generator" "7.0.0-beta.34"
-    "@babel/helpers" "7.0.0-beta.34"
-    "@babel/template" "7.0.0-beta.34"
-    "@babel/traverse" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
-    babylon "7.0.0-beta.34"
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/core@^7.0.0-beta.36":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fcore/-/core-7.0.0-beta.38.tgz#f669abfd5ca918a53cfef45eb57d9efd8d8eac5b"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.38"
+    "@babel/generator" "7.0.0-beta.38"
+    "@babel/helpers" "7.0.0-beta.38"
+    "@babel/template" "7.0.0-beta.38"
+    "@babel/traverse" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
+    babylon "7.0.0-beta.38"
     convert-source-map "^1.1.0"
     debug "^3.0.1"
     json5 "^0.5.0"
@@ -37,11 +45,11 @@
     resolve "^1.3.2"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.34.tgz#1a98992f3ef9e61a6007830883dfa2dbb26c622d"
+"@babel/generator@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fgenerator/-/generator-7.0.0-beta.38.tgz#6115a66663e3adfd1d6844029ffb2354680182eb"
   dependencies:
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/types" "7.0.0-beta.38"
     jsesc "^2.5.1"
     lodash "^4.2.0"
     source-map "^0.5.0"
@@ -53,11 +61,11 @@
   dependencies:
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-annotate-as-pure@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.34.tgz#f3c8951dc87f5700d6cc41cae8fa0db43393bc4e"
+"@babel/helper-annotate-as-pure@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.38.tgz#888cf28a1b9094d670dbdb1be1ec550b40c2dd9c"
   dependencies:
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/types" "7.0.0-beta.38"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -66,11 +74,11 @@
     "@babel/helper-explode-assignable-expression" "7.0.0-beta.31"
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-builder-react-jsx@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.34.tgz#a2fbc88640795d44001876e12e363ebfe6e1df3e"
+"@babel/helper-builder-react-jsx@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.38.tgz#a6f8ffcdd3d48a257e33cfcc1f089e16bd2ce7de"
   dependencies:
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/types" "7.0.0-beta.38"
     esutils "^2.0.0"
 
 "@babel/helper-call-delegate@7.0.0-beta.31":
@@ -105,13 +113,21 @@
     "@babel/traverse" "7.0.0-beta.31"
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-function-name@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.34.tgz#eb27e7ebc299b66981100005642bf50946cb14f9"
+"@babel/helper-function-name@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-function-name/-/helper-function-name-7.0.0-beta.36.tgz#366e3bc35147721b69009f803907c4d53212e88d"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.34"
-    "@babel/template" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/helper-get-function-arity" "7.0.0-beta.36"
+    "@babel/template" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/helper-function-name@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-function-name/-/helper-function-name-7.0.0-beta.38.tgz#dc6e74930efc7b0236b5ba72a633d34c778ba015"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.38"
+    "@babel/template" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
 
 "@babel/helper-get-function-arity@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -119,11 +135,17 @@
   dependencies:
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-get-function-arity@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.34.tgz#e3dd0a72086a739c587424abd26fd3012a8b1eec"
+"@babel/helper-get-function-arity@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz#f5383bac9a96b274828b10d98900e84ee43e32b8"
   dependencies:
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/helper-get-function-arity@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz#5c27de7641ac31da6e947dcc8009bd31282d9d84"
+  dependencies:
+    "@babel/types" "7.0.0-beta.38"
 
 "@babel/helper-hoist-variables@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -160,9 +182,9 @@
   dependencies:
     lodash "^4.2.0"
 
-"@babel/helper-regex@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.34.tgz#761224365616ef0652491920848fd27cf65f85d2"
+"@babel/helper-regex@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-regex/-/helper-regex-7.0.0-beta.38.tgz#3d6ff2bf9d2d1fc6e03cf7f1ec962a7f76fd5cd0"
   dependencies:
     lodash "^4.2.0"
 
@@ -175,15 +197,15 @@
     "@babel/traverse" "7.0.0-beta.31"
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-remap-async-to-generator@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.34.tgz#30d0ecc53e203a0d029ebc056726c3a07d545443"
+"@babel/helper-remap-async-to-generator@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.38.tgz#6e21e1520342d5567db08a033c313cfa7c846a20"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.34"
-    "@babel/helper-wrap-function" "7.0.0-beta.34"
-    "@babel/template" "7.0.0-beta.34"
-    "@babel/traverse" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.38"
+    "@babel/helper-wrap-function" "7.0.0-beta.38"
+    "@babel/template" "7.0.0-beta.38"
+    "@babel/traverse" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
 
 "@babel/helper-replace-supers@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -211,22 +233,22 @@
     "@babel/traverse" "7.0.0-beta.31"
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/helper-wrap-function@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.34.tgz#dd17517c73c3ded126d295d848af93aa3ca8f316"
+"@babel/helper-wrap-function@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelper-wrap-function/-/helper-wrap-function-7.0.0-beta.38.tgz#91605a09a193cf6939489f7fc066a353876ee506"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.34"
-    "@babel/template" "7.0.0-beta.34"
-    "@babel/traverse" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/helper-function-name" "7.0.0-beta.38"
+    "@babel/template" "7.0.0-beta.38"
+    "@babel/traverse" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
 
-"@babel/helpers@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.34.tgz#899dbe0a01c7a93a342860736ecf6419e2cc8591"
+"@babel/helpers@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fhelpers/-/helpers-7.0.0-beta.38.tgz#1e1695d55ead37757d339f5756b4c7316e0d70bb"
   dependencies:
-    "@babel/template" "7.0.0-beta.34"
-    "@babel/traverse" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
+    "@babel/template" "7.0.0-beta.38"
+    "@babel/traverse" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
 
 "@babel/plugin-check-constants@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -239,19 +261,19 @@
     "@babel/helper-remap-async-to-generator" "7.0.0-beta.31"
     "@babel/plugin-syntax-async-generators" "7.0.0-beta.31"
 
-"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.34.tgz#0a7b6385653b0df8b082d7f28ab4d1be05332386"
+"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.38.tgz#47d5a95698f7b55d8a73aade719c0c5c3e340896"
   dependencies:
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.34"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.34"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.38"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.38"
 
-"@babel/plugin-proposal-class-properties@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.34.tgz#3008cbe8d48f36a0610eebf78ef64dc3029a7f87"
+"@babel/plugin-proposal-class-properties@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.38.tgz#3cfa2fdedf7017ee14472d6859c3fb98654c0f22"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.34"
-    "@babel/plugin-syntax-class-properties" "7.0.0-beta.34"
+    "@babel/helper-function-name" "7.0.0-beta.38"
+    "@babel/plugin-syntax-class-properties" "7.0.0-beta.38"
 
 "@babel/plugin-proposal-object-rest-spread@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -259,11 +281,11 @@
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.31"
 
-"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.34.tgz#46720e93548d7504a11933b720bd3784426a9026"
+"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.38.tgz#4c9bee9cd4d905bf7531a722daf430183282c000"
   dependencies:
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.34"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.38"
 
 "@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -271,11 +293,11 @@
   dependencies:
     "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.31"
 
-"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.34.tgz#c38835ef180116d05ed57e4a6db6e77c97177fdc"
+"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.38.tgz#9f6b9e8540d374d9a2a17b96243768f2d22d0366"
   dependencies:
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.34"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.38"
 
 "@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -284,48 +306,56 @@
     "@babel/helper-regex" "7.0.0-beta.31"
     regexpu-core "^4.1.3"
 
-"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.34.tgz#7f22b2ec60e79b0394bf2a4e396eee1ef677db5b"
+"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.38.tgz#dde2dbe98ee6cae5bbb8c33097a2cc2566b3ef4e"
   dependencies:
-    "@babel/helper-regex" "7.0.0-beta.34"
+    "@babel/helper-regex" "7.0.0-beta.38"
     regexpu-core "^4.1.3"
 
 "@babel/plugin-syntax-async-generators@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.31.tgz#f7347f918941c2106b246adfa87bdc439d797e01"
 
-"@babel/plugin-syntax-async-generators@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.34.tgz#8f3990ec7f98ded0ede1edc65a636bebc63fa34b"
+"@babel/plugin-syntax-async-generators@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.38.tgz#1224bcd4a5052e6e4c0eb95c96bbe9f617a119f4"
 
-"@babel/plugin-syntax-class-properties@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.34.tgz#d345b262622ff9500d9ad039aa0b77a94b4b8dd5"
+"@babel/plugin-syntax-class-properties@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.38.tgz#e06a9bf6446611d78dfc71f84cddfe9219fb2829"
 
-"@babel/plugin-syntax-dynamic-import@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.34.tgz#05b1e58e4c3f412edb28aa0346c14c5f13c41b46"
+"@babel/plugin-syntax-dynamic-import@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.38.tgz#b74bc5d57b4cbe6a341570ea6d7db9ffba450f7b"
 
-"@babel/plugin-syntax-jsx@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.34.tgz#15763aaa2ef2df00fb9ff6edb7b4295622e52514"
+"@babel/plugin-syntax-flow@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.38.tgz#49b6ef92149fefa09c85fd31ca1f5c292a08ec06"
+
+"@babel/plugin-syntax-import-meta@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.38.tgz#0da0626a421cc21993326612d7bc92f25a3ab9cf"
+
+"@babel/plugin-syntax-jsx@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.38.tgz#1644f05630105cdbf0d6b4285f62af79fd8dd37f"
 
 "@babel/plugin-syntax-object-rest-spread@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.31.tgz#bd0f67210b3022182dc50d155393ccec720ca039"
 
-"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.34.tgz#01883a3e6e29d842e88c54d146addd88eedbe0e8"
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.38.tgz#a7288d08b5f3a3bf823c76f11118eb43dee74d43"
 
 "@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.31.tgz#9a999ecc49c6c55bd040622bcf6661824bdaa088"
 
-"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.34.tgz#b677c0863cd2373b46fc57728277212f331d6c2e"
+"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.38.tgz#99248ece1c5c6111d71182e206682048d93759e4"
 
 "@babel/plugin-transform-arrow-functions@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -385,6 +415,12 @@
   resolved "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.31.tgz#2b6090f2138e180acb3246dc1a13dd4a78600383"
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.31"
+
+"@babel/plugin-transform-flow-strip-types@^7.0.0-beta.36":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.38.tgz#a169de5b1dc6ac87f95e41f4cebc34d5c188ab9a"
+  dependencies:
+    "@babel/plugin-syntax-flow" "7.0.0-beta.38"
 
 "@babel/plugin-transform-for-of@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -448,28 +484,28 @@
     "@babel/traverse" "7.0.0-beta.31"
     "@babel/types" "7.0.0-beta.31"
 
-"@babel/plugin-transform-react-display-name@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.34.tgz#9cc093b34655aeefc4ce4e5925a30cd489798872"
+"@babel/plugin-transform-react-display-name@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.38.tgz#95b406c30fd6569f90e15003b2b9296c38d0b77e"
 
-"@babel/plugin-transform-react-jsx-self@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.34.tgz#7088b22f6e59b6f9ca4f03bd439eb22b7b612b22"
+"@babel/plugin-transform-react-jsx-self@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.38.tgz#1cd41178d16373a64280de0d62355c96e8fbe6af"
   dependencies:
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.34"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.38"
 
-"@babel/plugin-transform-react-jsx-source@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.34.tgz#53081f5e4ec9fa76ce3f882297b6af895b7893b3"
+"@babel/plugin-transform-react-jsx-source@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.38.tgz#05e4420dc2b6368f22ce83b29fb86a08ad22fadf"
   dependencies:
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.34"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.38"
 
-"@babel/plugin-transform-react-jsx@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.34.tgz#e34e47c71c7efa6a9362176fdf5d3ae16368a117"
+"@babel/plugin-transform-react-jsx@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fplugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.38.tgz#6abd97c2dde5a007f0fba77d4c4bd7b2a68e7316"
   dependencies:
-    "@babel/helper-builder-react-jsx" "7.0.0-beta.34"
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.34"
+    "@babel/helper-builder-react-jsx" "7.0.0-beta.38"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.38"
 
 "@babel/plugin-transform-regenerator@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -511,26 +547,27 @@
     "@babel/helper-regex" "7.0.0-beta.31"
     regexpu-core "^4.1.3"
 
-"@babel/preset-react@^7.0.0-beta.32":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.34.tgz#548d8bca75c70c24a2ec0ebc2bd59d9f18ddfd7c"
+"@babel/preset-react@^7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fpreset-react/-/preset-react-7.0.0-beta.38.tgz#eb42433a72314f14f28be7fe2b092c9a9a3294cb"
   dependencies:
-    "@babel/plugin-syntax-jsx" "7.0.0-beta.34"
-    "@babel/plugin-transform-react-display-name" "7.0.0-beta.34"
-    "@babel/plugin-transform-react-jsx" "7.0.0-beta.34"
-    "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.34"
-    "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.34"
+    "@babel/plugin-syntax-jsx" "7.0.0-beta.38"
+    "@babel/plugin-transform-react-display-name" "7.0.0-beta.38"
+    "@babel/plugin-transform-react-jsx" "7.0.0-beta.38"
+    "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.38"
+    "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.38"
 
-"@babel/preset-stage-3@^7.0.0-beta.31":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/preset-stage-3/-/preset-stage-3-7.0.0-beta.34.tgz#0de1c1833f337c29ab4e7547fbd1d0005b726fd1"
+"@babel/preset-stage-3@^7.0.0-beta.36":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2fpreset-stage-3/-/preset-stage-3-7.0.0-beta.38.tgz#f542ca4f043ddeb4456ac671b5f9ab47e9ab1456"
   dependencies:
-    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.34"
-    "@babel/plugin-proposal-class-properties" "7.0.0-beta.34"
-    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.34"
-    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.34"
-    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.34"
-    "@babel/plugin-syntax-dynamic-import" "7.0.0-beta.34"
+    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.38"
+    "@babel/plugin-proposal-class-properties" "7.0.0-beta.38"
+    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.38"
+    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.38"
+    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.38"
+    "@babel/plugin-syntax-dynamic-import" "7.0.0-beta.38"
+    "@babel/plugin-syntax-import-meta" "7.0.0-beta.38"
 
 "@babel/template@7.0.0-beta.31":
   version "7.0.0-beta.31"
@@ -541,13 +578,22 @@
     babylon "7.0.0-beta.31"
     lodash "^4.2.0"
 
-"@babel/template@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.34.tgz#35fa7eb6c540f4619927ec1c1b113719ecc59446"
+"@babel/template@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2ftemplate/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
-    babylon "7.0.0-beta.34"
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    lodash "^4.2.0"
+
+"@babel/template@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2ftemplate/-/template-7.0.0-beta.38.tgz#8a2d403a01da320beb8333dc6403500fa79e8597"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
+    babylon "7.0.0-beta.38"
     lodash "^4.2.0"
 
 "@babel/traverse@7.0.0-beta.31":
@@ -563,16 +609,30 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/traverse@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.34.tgz#c352fc560e1c78198ee52252c780fe848235fdfe"
+"@babel/traverse@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2ftraverse/-/traverse-7.0.0-beta.36.tgz#1dc6f8750e89b6b979de5fe44aa993b1a2192261"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.34"
-    "@babel/helper-function-name" "7.0.0-beta.34"
-    "@babel/types" "7.0.0-beta.34"
-    babylon "7.0.0-beta.34"
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/helper-function-name" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
     debug "^3.0.1"
-    globals "^10.0.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2ftraverse/-/traverse-7.0.0-beta.38.tgz#56462b91753dd5c6faf36e56a77c64077ddb85b8"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.38"
+    "@babel/generator" "7.0.0-beta.38"
+    "@babel/helper-function-name" "7.0.0-beta.38"
+    "@babel/types" "7.0.0-beta.38"
+    babylon "7.0.0-beta.38"
+    debug "^3.0.1"
+    globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
@@ -584,9 +644,17 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@babel/types@7.0.0-beta.34":
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.34.tgz#ce8da730b834c782ec64a2baf3ac0200dd328816"
+"@babel/types@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/@babel%2ftypes/-/types-7.0.0-beta.36.tgz#64f2004353de42adb72f9ebb4665fc35b5499d23"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/@babel%2ftypes/-/types-7.0.0-beta.38.tgz#2ce2443f7dc6ad535a67db4940cbd34e64035a6f"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -634,13 +702,25 @@
     invariant "^2.2.2"
     semver "^5.3.0"
 
+"@types/core-js@^0.9.41":
+  version "0.9.46"
+  resolved "https://unpm.uberinternal.com/@types%2fcore-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
+
+"@types/mkdirp@^0.3.29":
+  version "0.3.29"
+  resolved "https://unpm.uberinternal.com/@types%2fmkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
+
 "@types/node@*":
   version "8.5.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
 
-"@types/node@^7.0.18":
-  version "7.0.50"
-  resolved "https://registry.npmjs.org/@types/node/-/node-7.0.50.tgz#432428edab1073d478924d80a58a250b390c7b1b"
+"@types/node@^9.3.0":
+  version "9.3.0"
+  resolved "https://unpm.uberinternal.com/@types%2fnode/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
+
+"@types/rimraf@^0.0.28":
+  version "0.0.28"
+  resolved "https://unpm.uberinternal.com/@types%2frimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
 
 abbrev@1:
   version "1.1.1"
@@ -692,7 +772,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
@@ -773,9 +853,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-args@^3.0.7:
+args@^3.0.8:
   version "3.0.8"
-  resolved "https://registry.npmjs.org/args/-/args-3.0.8.tgz#2f425ab639c69d74ff728f3d7c6e93b97b91af7c"
+  resolved "https://unpm.uberinternal.com/args/-/args-3.0.8.tgz#2f425ab639c69d74ff728f3d7c6e93b97b91af7c"
   dependencies:
     camelcase "4.1.0"
     chalk "2.1.0"
@@ -796,10 +876,6 @@ arr-flatten@^1.0.1:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
-
-array-find-index@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -864,6 +940,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -882,11 +962,7 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -898,14 +974,16 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-eslint@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz#f29ecf02336be438195325cd47c468da81ee4e98"
+babel-eslint@^8.2.1:
+  version "8.2.1"
+  resolved "https://unpm.uberinternal.com/babel-eslint/-/babel-eslint-8.2.1.tgz#136888f3c109edc65376c23ebf494f36a3e03951"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.31"
-    "@babel/traverse" "7.0.0-beta.31"
-    "@babel/types" "7.0.0-beta.31"
-    babylon "7.0.0-beta.31"
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/traverse" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.18.0:
   version "6.26.0"
@@ -990,19 +1068,17 @@ babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
-babylon@7.0.0-beta.34:
-  version "7.0.0-beta.34"
-  resolved "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.34.tgz#2ccdf97bb4fbc1617619a030a6c0390b2c8f16d6"
+babylon@7.0.0-beta.36:
+  version "7.0.0-beta.36"
+  resolved "https://unpm.uberinternal.com/babylon/-/babylon-7.0.0-beta.36.tgz#3a3683ba6a9a1e02b0aa507c8e63435e39305b9e"
+
+babylon@7.0.0-beta.38:
+  version "7.0.0-beta.38"
+  resolved "https://unpm.uberinternal.com/babylon/-/babylon-7.0.0-beta.38.tgz#9b3a33e571a47464a2d20cb9dd5a570f00e3f996"
 
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
-backoff@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
-  dependencies:
-    precond "0.2"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1045,18 +1121,6 @@ boom@2.x.x:
   resolved "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1174,13 +1238,6 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-camelcase-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  dependencies:
-    camelcase "^2.0.0"
-    map-obj "^1.0.0"
-
 camelcase@4.1.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -1188,10 +1245,6 @@ camelcase@4.1.0, camelcase@^4.1.0:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-
-camelcase@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 caniuse-lite@^1.0.30000780:
   version "1.0.30000783"
@@ -1264,6 +1317,26 @@ chokidar@^1.7.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chrome-launcher@^0.10.0:
+  version "0.10.2"
+  resolved "https://unpm.uberinternal.com/chrome-launcher/-/chrome-launcher-0.10.2.tgz#f7d860ddec627b6f01015736b5ae1e33b3d165b1"
+  dependencies:
+    "@types/core-js" "^0.9.41"
+    "@types/mkdirp" "^0.3.29"
+    "@types/node" "^9.3.0"
+    "@types/rimraf" "^0.0.28"
+    is-wsl "^1.1.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "0.5.1"
+    rimraf "^2.6.1"
+
+chrome-remote-interface@^0.25.5:
+  version "0.25.5"
+  resolved "https://unpm.uberinternal.com/chrome-remote-interface/-/chrome-remote-interface-0.25.5.tgz#cfd3fb124bf5f2ea5a9d72037527c156822b1406"
+  dependencies:
+    commander "2.11.x"
+    ws "3.3.x"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -1329,6 +1402,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.11.x:
+  version "2.11.0"
+  resolved "https://unpm.uberinternal.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -1337,7 +1414,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.6.0:
+concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1421,29 +1498,30 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-universal-package@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/create-universal-package/-/create-universal-package-2.1.1.tgz#170877cb6725d8494efb757005eb5aca9ee5edde"
+create-universal-package@^3.2.6:
+  version "3.2.6"
+  resolved "https://unpm.uberinternal.com/create-universal-package/-/create-universal-package-3.2.6.tgz#8269a7ac8ad5d1e13139a36f18d139fb48000483"
   dependencies:
-    "@babel/core" "^7.0.0-beta.31"
-    "@babel/preset-stage-3" "^7.0.0-beta.31"
+    "@babel/core" "^7.0.0-beta.36"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0-beta.36"
+    "@babel/preset-stage-3" "^7.0.0-beta.36"
     "@rtsao/babel-preset-env" "^7.0.0-beta.31"
-    args "^3.0.7"
+    args "^3.0.8"
     babel-plugin-istanbul "^4.1.5"
     babel-plugin-transform-cup-globals "^1.0.0"
     chalk "^2.3.0"
     draftlog "^1.0.12"
     fast-async "^6.3.0"
     import-lazy "^3.1.0"
-    jest-worker "^21.3.0-beta.8"
+    jest-worker "^22.0.3"
     loader-utils "^1.1.0"
     multi-entry-loader "^1.1.2"
     rimraf "^2.6.2"
-    rollup "^0.51.1"
+    rollup "^0.53.2"
     rollup-plugin-memory "^2.0.0"
     rollup-plugin-multi-entry "^2.0.2"
     rollup-pluginutils "^2.0.1"
-    webpack "^3.8.1"
+    webpack "^3.10.0"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -1465,12 +1543,6 @@ cryptiles@2.x.x:
   resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -1501,12 +1573,6 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
-currently-unhandled@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
-  dependencies:
-    array-find-index "^1.0.1"
-
 d@1:
   version "1.0.0"
   resolved "https://registry.npmjs.org/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1533,13 +1599,13 @@ debug@*, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.8:
+debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1636,9 +1702,15 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.0.2:
+doctrine@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://unpm.uberinternal.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
 
@@ -1695,31 +1767,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-download@^3.0.1:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz#2cfd54d6966c019c4d49ad65fbe65cc9cdef68c8"
-  dependencies:
-    debug "^2.2.0"
-    fs-extra "^0.30.0"
-    home-path "^1.0.1"
-    minimist "^1.2.0"
-    nugget "^2.0.0"
-    path-exists "^2.1.0"
-    rc "^1.1.2"
-    semver "^5.3.0"
-    sumchecker "^1.2.0"
-
 electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
-
-electron@^1.4.13:
-  version "1.7.9"
-  resolved "https://registry.npmjs.org/electron/-/electron-1.7.9.tgz#add54e9f8f83ed02f6519ec10135f698b19336cf"
-  dependencies:
-    "@types/node" "^7.0.18"
-    electron-download "^3.0.1"
-    extract-zip "^1.0.3"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -1756,36 +1806,42 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-16@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz#86c5db7c10f0be6ec25d54ca41b59f2abb397cf4"
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://unpm.uberinternal.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
   dependencies:
-    enzyme-adapter-utils "^1.1.0"
+    enzyme-adapter-utils "^1.3.0"
     lodash "^4.17.4"
     object.assign "^4.0.4"
     object.values "^1.0.4"
-    prop-types "^15.5.10"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
     react-test-renderer "^16.0.0-0"
 
-enzyme-adapter-utils@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.2.0.tgz#7f4471ee0a70b91169ec8860d2bf0a6b551664b2"
+enzyme-adapter-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://unpm.uberinternal.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
   dependencies:
     lodash "^4.17.4"
     object.assign "^4.0.4"
-    prop-types "^15.5.10"
+    prop-types "^15.6.0"
 
-enzyme@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/enzyme/-/enzyme-3.2.0.tgz#998bdcda0fc71b8764a0017f7cc692c943f54a7a"
+enzyme@^3.3.0:
+  version "3.3.0"
+  resolved "https://unpm.uberinternal.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
   dependencies:
     cheerio "^1.0.0-rc.2"
     function.prototype.name "^1.0.3"
     has "^1.0.1"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.3"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
     is-subset "^0.1.1"
     lodash "^4.17.4"
+    object-inspect "^1.5.0"
     object-is "^1.0.1"
-    object.assign "^4.0.4"
+    object.assign "^4.1.0"
     object.entries "^1.0.4"
     object.values "^1.0.4"
     raf "^3.4.0"
@@ -1851,10 +1907,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@^4.0.5:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -1902,9 +1954,9 @@ eslint-config-cup@^1.0.0-rc.4:
   version "1.0.0"
   resolved "https://registry.npmjs.org/eslint-config-cup/-/eslint-config-cup-1.0.0.tgz#0fcdb787fe254fc9458ec5258143cb0d47052896"
 
-eslint-config-fusion@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/eslint-config-fusion/-/eslint-config-fusion-0.2.0.tgz#9a219e6a8d225d1fd59878455dbf1b8d3b8c0c34"
+eslint-config-fusion@^0.2.1:
+  version "0.2.1"
+  resolved "https://unpm.uberinternal.com/eslint-config-fusion/-/eslint-config-fusion-0.2.1.tgz#39db6979719dab00953e561b2ff0af66981397bb"
   dependencies:
     eslint-config-uber-universal-stage-3 "^1.0.0-rc.7"
 
@@ -1953,9 +2005,9 @@ eslint-plugin-cup@^1.0.0:
   dependencies:
     globals "^10.0.0"
 
-eslint-plugin-flowtype@^2.39.1:
-  version "2.40.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.40.1.tgz#f78a8e6a4cc6da831dd541eb61e803ff0279b796"
+eslint-plugin-flowtype@^2.42.0:
+  version "2.42.0"
+  resolved "https://unpm.uberinternal.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
   dependencies:
     lodash "^4.15.0"
 
@@ -1974,44 +2026,48 @@ eslint-plugin-import@^2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-prettier@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
+eslint-plugin-prettier@^2.5.0:
+  version "2.5.0"
+  resolved "https://unpm.uberinternal.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz#39a91dd7528eaf19cd42c0ee3f2c1f684606a05f"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-eslint-plugin-react@^7.4.0:
-  version "7.5.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
+eslint-plugin-react@^7.6.0:
+  version "7.6.0"
+  resolved "https://unpm.uberinternal.com/eslint-plugin-react/-/eslint-plugin-react-7.6.0.tgz#351651188c74c5b2fecc2717e3936b7207baa728"
   dependencies:
-    doctrine "^2.0.0"
+    doctrine "^2.0.2"
     has "^1.0.1"
-    jsx-ast-utils "^2.0.0"
+    jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
-eslint-scope@^3.7.1:
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  resolved "https://unpm.uberinternal.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.11.0:
-  version "4.13.1"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz#0055e0014464c7eb7878caf549ef2941992b444f"
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.16.0:
+  version "4.16.0"
+  resolved "https://unpm.uberinternal.com/eslint/-/eslint-4.16.0.tgz#934ada9e98715e1d7bbfd6f6f0519ed2fab35cc1"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^3.0.1"
-    doctrine "^2.0.2"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
     espree "^3.5.2"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
@@ -2063,7 +2119,7 @@ esrecurse@^4.1.0:
     estraverse "^4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -2105,10 +2161,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exit-code@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/exit-code/-/exit-code-1.0.2.tgz#ce165811c9f117af6a5f882940b96ae7f9aecc34"
-
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -2133,7 +2185,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -2150,15 +2202,6 @@ extglob@^0.3.1:
   resolved "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
-
-extract-zip@^1.0.3:
-  version "1.6.6"
-  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
-  dependencies:
-    concat-stream "1.6.0"
-    debug "2.6.9"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -2202,12 +2245,6 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
-
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  dependencies:
-    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2266,9 +2303,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.64.0:
+  version "0.64.0"
+  resolved "https://unpm.uberinternal.com/flow-bin/-/flow-bin-0.64.0.tgz#ddd3fb3b183ab1ab35a5d5dec9caf5ebbcded167"
 
 for-each@~0.3.2:
   version "0.3.2"
@@ -2309,14 +2346,6 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -2324,16 +2353,6 @@ fresh@^0.5.2:
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
-
-fs-extra@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2379,9 +2398,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@^0.2.3:
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/fusion-core/-/fusion-core-0.2.6.tgz#d65610327153bebed7162e5823fcda10ddb40366"
+fusion-core@^0.2.8:
+  version "0.2.8"
+  resolved "https://unpm.uberinternal.com/fusion-core/-/fusion-core-0.2.8.tgz#90413a044483a91143c6b8b800237b738a4f1495"
   dependencies:
     koa "^2.3.0"
     koa-compose "^4.0.0"
@@ -2404,9 +2423,9 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-stdin@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+get-port@^3.2.0:
+  version "3.2.0"
+  resolved "https://unpm.uberinternal.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
 
 get-stdin@^5.0.1:
   version "5.0.1"
@@ -2421,10 +2440,6 @@ getpass@^0.1.1:
   resolved "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
-
-getport@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2481,6 +2496,10 @@ globals@^11.0.1:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
 
+globals@^11.1.0:
+  version "11.2.0"
+  resolved "https://unpm.uberinternal.com/globals/-/globals-11.2.0.tgz#aa2ece052a787563ba70a3dcd9dc2eb8a9a0488c"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2496,7 +2515,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2514,23 +2533,12 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -2551,6 +2559,10 @@ has-glob@^0.1.1:
   resolved "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz#a261c4c2a6c667e0c77b700a7f297c39ef3aa589"
   dependencies:
     is-glob "^2.0.1"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2591,15 +2603,6 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 highland@^2.5.1:
   version "2.11.1"
   resolved "https://registry.npmjs.org/highland/-/highland-2.11.1.tgz#39b4d9299b6e07da3d15e7af7b2a6f127522acaf"
@@ -2617,14 +2620,6 @@ hmac-drbg@^1.0.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
-
-home-path@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
 
 homedir-polyfill@^1.0.0:
   version "1.0.1"
@@ -2671,14 +2666,6 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
@@ -2702,12 +2689,6 @@ import-lazy@^3.1.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  dependencies:
-    repeating "^2.0.0"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -2775,6 +2756,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -2792,6 +2777,10 @@ is-callable@^1.1.1, is-callable@^1.1.3:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-docker@^1.1.0:
+  version "1.1.0"
+  resolved "https://unpm.uberinternal.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -2851,6 +2840,10 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://unpm.uberinternal.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2905,6 +2898,10 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://unpm.uberinternal.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
@@ -2929,9 +2926,9 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://unpm.uberinternal.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2958,7 +2955,7 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
+istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
@@ -3009,9 +3006,9 @@ jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-jest-worker@^21.3.0-beta.8:
-  version "21.3.0-beta.14"
-  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.14.tgz#4247db4f55903612eb41b609d16663c864946e74"
+jest-worker@^22.0.3:
+  version "22.1.0"
+  resolved "https://unpm.uberinternal.com/jest-worker/-/jest-worker-22.1.0.tgz#0987832fe58fbdc205357f4c19b992446368cafb"
   dependencies:
     merge-stream "^1.0.1"
 
@@ -3072,12 +3069,6 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3091,9 +3082,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.0.0:
+jsx-ast-utils@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  resolved "https://unpm.uberinternal.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
 
@@ -3112,12 +3103,6 @@ kind-of@^4.0.0:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 koa-compose@^3.0.0:
   version "3.2.1"
@@ -3192,6 +3177,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lighthouse-logger@^1.0.0:
+  version "1.0.1"
+  resolved "https://unpm.uberinternal.com/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz#f073d83f7acbc96729bf100a121c8f006991ae61"
+  dependencies:
+    debug "^2.6.8"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3252,23 +3243,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
-loud-rejection@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.0"
-
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-map-obj@^1.0.0, map-obj@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
 matched@^0.4.4:
   version "0.4.4"
@@ -3318,21 +3298,6 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.1.0:
-  version "3.7.0"
-  resolved "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  dependencies:
-    camelcase-keys "^2.0.0"
-    decamelize "^1.1.2"
-    loud-rejection "^1.0.0"
-    map-obj "^1.0.1"
-    minimist "^1.1.3"
-    normalize-package-data "^2.3.4"
-    object-assign "^4.0.1"
-    read-pkg-up "^1.0.1"
-    redent "^1.0.0"
-    trim-newlines "^1.0.0"
-
 merge-descriptors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -3349,9 +3314,9 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-merge2@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/merge2/-/merge2-1.0.3.tgz#fa44f8b2262615ab72f0808a401d478a70e394db"
+merge2@1.2.0:
+  version "1.2.0"
+  resolved "https://unpm.uberinternal.com/merge2/-/merge2-1.2.0.tgz#0f882151d988b1f3d0758945404fa73ee5923d3f"
 
 methods@^1.1.2:
   version "1.1.2"
@@ -3386,7 +3351,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -3418,7 +3383,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
+minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3426,13 +3391,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
-
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3454,9 +3413,9 @@ multi-entry-loader@^1.1.2:
     loader-utils "^1.1.0"
     matched "^0.4.4"
 
-multistream@^2.0.5:
+multistream@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/multistream/-/multistream-2.1.0.tgz#625c267d5c44424ad6294788b5bb4da3dcb32f1d"
+  resolved "https://unpm.uberinternal.com/multistream/-/multistream-2.1.0.tgz#625c267d5c44424ad6294788b5bb4da3dcb32f1d"
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.5"
@@ -3581,7 +3540,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3617,25 +3576,13 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nugget@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
-  dependencies:
-    debug "^2.1.3"
-    minimist "^1.1.0"
-    pretty-bytes "^1.0.2"
-    progress-stream "^1.1.0"
-    request "^2.45.0"
-    single-line-log "^1.1.2"
-    throttleit "0.0.2"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.npmjs.org/nyc/-/nyc-11.3.0.tgz#a42bc17b3cfa41f7b15eb602bc98b2633ddd76f0"
+nyc@^11.4.1:
+  version "11.4.1"
+  resolved "https://unpm.uberinternal.com/nyc/-/nyc-11.4.1.tgz#13fdf7e7ef22d027c61d174758f6978a68f4f5e5"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -3660,18 +3607,22 @@ nyc@^11.3.0:
     resolve-from "^2.0.0"
     rimraf "^2.5.4"
     signal-exit "^3.0.1"
-    spawn-wrap "=1.3.8"
+    spawn-wrap "^1.4.2"
     test-exclude "^4.1.1"
     yargs "^10.0.3"
     yargs-parser "^8.0.0"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@^1.5.0:
+  version "1.5.0"
+  resolved "https://unpm.uberinternal.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
 
 object-inspect@~1.3.0:
   version "1.3.0"
@@ -3681,13 +3632,9 @@ object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
+object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object-keys@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object.assign@^4.0.4:
   version "4.0.4"
@@ -3696,6 +3643,15 @@ object.assign@^4.0.4:
     define-properties "^1.1.2"
     function-bind "^1.1.0"
     object-keys "^1.0.10"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://unpm.uberinternal.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.entries@^1.0.4:
   version "1.0.4"
@@ -3854,7 +3810,7 @@ path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
-path-exists@^2.0.0, path-exists@^2.1.0:
+path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
@@ -3904,10 +3860,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -3944,10 +3896,6 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-precond@0.2:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -3956,16 +3904,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.8.2:
-  version "1.8.2"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
-
-pretty-bytes@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
-  dependencies:
-    get-stdin "^4.0.1"
-    meow "^3.1.0"
+prettier@1.10.2:
+  version "1.10.2"
+  resolved "https://unpm.uberinternal.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 private@^0.1.6:
   version "0.1.8"
@@ -3979,13 +3920,6 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-progress-stream@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz#2cd3cfea33ba3a89c9c121ec3347abe9ab125f77"
-  dependencies:
-    speedometer "~0.1.2"
-    through2 "~0.2.3"
-
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -3996,7 +3930,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0:
+prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -4033,10 +3967,6 @@ punycode@^1.2.4, punycode@^1.4.1:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -4087,7 +4017,7 @@ range-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-rc@^1.1.2, rc@^1.1.7:
+rc@^1.1.7:
   version "1.2.2"
   resolved "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
@@ -4096,9 +4026,18 @@ rc@^1.1.2, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.1.1:
+react-dom@^16.2.0:
   version "16.2.0"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  resolved "https://unpm.uberinternal.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://unpm.uberinternal.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4113,9 +4052,9 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.1.1:
+react@^16.2.0:
   version "16.2.0"
-  resolved "https://registry.npmjs.org/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  resolved "https://unpm.uberinternal.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4164,15 +4103,6 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -4181,13 +4111,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-redent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  dependencies:
-    indent-string "^2.1.0"
-    strip-indent "^1.0.1"
 
 regenerate-unicode-properties@^5.1.1:
   version "5.1.3"
@@ -4282,33 +4205,6 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.45.0:
-  version "2.83.0"
-  resolved "https://registry.npmjs.org/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -4374,7 +4270,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -4404,9 +4300,9 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^0.51.1:
-  version "0.51.8"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-0.51.8.tgz#58bd0b642885f4770b5f93cc64f14e4233c2236d"
+rollup@^0.53.2:
+  version "0.53.4"
+  resolved "https://unpm.uberinternal.com/rollup/-/rollup-0.53.4.tgz#f92ce56ee1d097ad5b6f13951bc80db5fef18113"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -4486,12 +4382,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-single-line-log@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz#c2f83f273a3e1a16edb0995661da0ed5ef033364"
-  dependencies:
-    string-width "^1.0.1"
-
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
@@ -4507,12 +4397,6 @@ sntp@1.x.x:
   resolved "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
-
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -4532,16 +4416,16 @@ source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-spawn-wrap@=1.3.8:
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz#fa2a79b990cbb0bb0018dca6748d88367b19ec31"
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://unpm.uberinternal.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
   dependencies:
     foreground-child "^1.5.6"
     mkdirp "^0.5.0"
     os-homedir "^1.0.1"
-    rimraf "^2.3.3"
+    rimraf "^2.6.2"
     signal-exit "^3.0.2"
-    which "^1.2.4"
+    which "^1.3.0"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -4556,10 +4440,6 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
-
-speedometer@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
 
 split@~0.1.2:
   version "0.1.2"
@@ -4641,11 +4521,7 @@ string_decoder@^1.0.0, string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -4675,22 +4551,9 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-indent@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  dependencies:
-    get-stdin "^4.0.1"
-
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-sumchecker@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz#79bb3b4456dd04f18ebdbc0d703a1d1daec5105d"
-  dependencies:
-    debug "^2.2.0"
-    es6-promise "^4.0.5"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -4801,17 +4664,6 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-throttleit@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
-
-through2@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
-  dependencies:
-    readable-stream "~1.1.9"
-    xtend "~2.1.1"
-
 through@1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/through/-/through-1.1.2.tgz#344a5425a3773314ca7e0eb6512fbafaf76c0bfe"
@@ -4850,15 +4702,11 @@ to-object-path@^0.3.0:
   dependencies:
     kind-of "^3.0.2"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.0:
   version "2.3.3"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
-
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -4924,6 +4772,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://unpm.uberinternal.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
@@ -4947,18 +4799,18 @@ unicode-property-aliases-ecmascript@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz#ac3522583b9e630580f916635333e00c5ead690d"
 
-unitest@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/unitest/-/unitest-1.1.0.tgz#c5969513aac2ef0a926bb1f8bba481c07f323d65"
+unitest@^2.1.1:
+  version "2.1.1"
+  resolved "https://unpm.uberinternal.com/unitest/-/unitest-2.1.1.tgz#ca349e320ba3d7ea1843a9f2f74683930595b7b9"
   dependencies:
-    backoff "^2.5.0"
-    electron "^1.4.13"
-    exit-code "^1.0.2"
-    getport "^0.1.0"
-    istanbul-lib-coverage "^1.0.1"
-    merge2 "1.0.3"
+    chrome-launcher "^0.10.0"
+    chrome-remote-interface "^0.25.5"
+    get-port "^3.2.0"
+    is-docker "^1.1.0"
+    istanbul-lib-coverage "^1.1.1"
+    merge2 "1.2.0"
     minimist "^1.2.0"
-    multistream "^2.0.5"
+    multistream "^2.1.0"
     run-parallel "^1.1.6"
     tap-finished "0.0.1"
     tap-merge "^0.3.1"
@@ -4980,7 +4832,7 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -5024,9 +4876,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^3.8.1:
+webpack@^3.10.0:
   version "3.10.0"
-  resolved "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
+  resolved "https://unpm.uberinternal.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -5059,7 +4911,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.4, which@^1.2.9:
+which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -5112,15 +4964,17 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@3.3.x:
+  version "3.3.3"
+  resolved "https://unpm.uberinternal.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
-  dependencies:
-    object-keys "~0.4.0"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -5185,9 +5039,3 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,13 +2398,14 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@^0.2.8:
-  version "0.2.8"
-  resolved "https://unpm.uberinternal.com/fusion-core/-/fusion-core-0.2.8.tgz#90413a044483a91143c6b8b800237b738a4f1495"
+fusion-core@^0.3.0-5:
+  version "0.3.0-5"
+  resolved "https://unpm.uberinternal.com/fusion-core/-/fusion-core-0.3.0-5.tgz#b6ad6ea3f7dcdb6517dc31214f64856727c5800c"
   dependencies:
     koa "^2.3.0"
     koa-compose "^4.0.0"
     node-mocks-http "^1.6.6"
+    toposort "^1.0.6"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -4701,6 +4702,10 @@ to-object-path@^0.3.0:
   resolved "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
   dependencies:
     kind-of "^3.0.2"
+
+toposort@^1.0.6:
+  version "1.0.6"
+  resolved "https://unpm.uberinternal.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
 
 tough-cookie@~2.3.0:
   version "2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,7 +926,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1:
+assert@^1.1.1, assert@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -2407,6 +2407,14 @@ fusion-core@^0.3.0-5:
     node-mocks-http "^1.6.6"
     toposort "^1.0.6"
 
+fusion-test-utils@^0.4.1:
+  version "0.4.1"
+  resolved "https://unpm.uberinternal.com/fusion-test-utils/-/fusion-test-utils-0.4.1.tgz#c834945eb0bdecc6f56993c4daaf4f4e13416029"
+  dependencies:
+    assert "^1.4.1"
+    koa "^2.4.1"
+    node-mocks-http "^1.6.6"
+
 fusion-tokens@0.0.5:
   version "0.0.5"
   resolved "https://unpm.uberinternal.com/fusion-tokens/-/fusion-tokens-0.0.5.tgz#71af057ab696046c43e89ca06dfe47cdbaeac6d8"
@@ -3130,7 +3138,7 @@ koa-is-json@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
 
-koa@^2.3.0:
+koa@^2.3.0, koa@^2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/koa/-/koa-2.4.1.tgz#d449cfb970a7e9da571f699eda40bb9e32eb1484"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,6 +2407,10 @@ fusion-core@^0.3.0-5:
     node-mocks-http "^1.6.6"
     toposort "^1.0.6"
 
+fusion-tokens@0.0.5:
+  version "0.0.5"
+  resolved "https://unpm.uberinternal.com/fusion-tokens/-/fusion-tokens-0.0.5.tgz#71af057ab696046c43e89ca06dfe47cdbaeac6d8"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
Fixes #19

Includes:
* Update dependencies to latest
* Migration of source and unit tests to `fusion-core@0.3.0-5`
* Update documentation and add a usage example