### PR TITLE
Remove fusion-tokens as peerDependency, promote prop-types to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0-beta.47",
     "babel-eslint": "^8.2.3",
@@ -37,8 +40,7 @@
     "eslint-plugin-react": "^7.8.2",
     "flow-bin": "^0.77.0",
     "fusion-core": "^1.3.1",
-    "fusion-test-utils": "^1.1.0",
-    "fusion-tokens": "^1.0.3",
+    "fusion-test-utils": "^1.2.2",
     "nyc": "^12.0.0",
     "prettier": "^1.12.1",
     "react": "^16.3.2",
@@ -48,8 +50,6 @@
   },
   "peerDependencies": {
     "fusion-core": "^1.0.0",
-    "fusion-tokens": "^1.0.1",
-    "prop-types": "^15.6.0",
     "react": "14.x - 16.x"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,17 +2667,13 @@ fusion-core@^1.3.1:
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
 
-fusion-test-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.1.0.tgz#1900a7d432733f935698ee139cef3a1e8f6ab973"
+fusion-test-utils@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.2.2.tgz#f1c72156012d4e0731875cd9b52d4ad426994a9b"
   dependencies:
     assert "^1.4.1"
     koa "^2.4.1"
     node-mocks-http "^1.6.6"
-
-fusion-tokens@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fusion-tokens/-/fusion-tokens-1.0.3.tgz#e247a076ef145337287e103ecbc42486594e96c5"
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
1) Removes fusion-tokens since it's unused now
2) Updates the pin for fusion-test-utils so we can remove fusion-tokens
3) Adds prop-types as a regular dependency as per the suggestion here: https://github.com/facebook/prop-types#how-to-depend-on-this-package