### PR TITLE
Load Polyfill font if document.fonts doesn't exist

### DIFF
--- a/src/font-loader.js
+++ b/src/font-loader.js
@@ -21,8 +21,8 @@ const testText = 'π+[.—_]imW12/?';
 const timeout = 60000;
 
 export default function(font: string) {
-  // $FlowFixMe
-  if (__BROWSER__ && document && document.fonts) {
+  if (__BROWSER__ && document) {
+    // $FlowFixMe
     return document.fonts && typeof document.fonts.load === 'function'
       ? document.fonts.load(`1em ${font}`) // native API requires size
       : loadFontPolyfill(font);


### PR DESCRIPTION
`document.fonts` check is redundant and evaluates to `undefined` in simulator test. In that case, the function returns `undefined` whereas the desired behavior is to load polyfill fonts.