### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ while loading font:
 
 ```js
 {
-  fontFamily: 'Lato-Regular';
-  fontWeight: 'bold';
+  fontFamily: 'Lato-Regular',
+  fontWeight: 'bold',
 }
 ```
 
@@ -123,7 +123,7 @@ when font is loaded:
 
 ```js
 {
-  fontFamily: 'Lato-Bold';
+  fontFamily: 'Lato-Bold',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For example, if you're using the `Lato` font family, you can defer loading of `L
 You can tune the balance between performance and user experience with simple configurations. This plugin generates inline @font-face CSS declarations and preloads fallback fonts based on a `preloadDepth` configuration vlue, which lets you specify how many fonts to preload and how many to load asynchronously.
 
 This package provides:
+
 1. A fusion plugin that generates @font-faces and preloads fallback fonts based on app-level font configuration.
 2. A Higher Order Component for loading custom web fonts (and associated utils). During font loading, this HOC temporarily swaps the element to a well-matched fallback font, avoiding FOIT and FOUT. See https://www.zachleat.com/web/comprehensive-webfonts/#critical-foft-preload for more on this.
 
@@ -20,6 +21,10 @@ This package provides:
 - [Usage](#usage)
 - [Setup](#setup)
 - [API](#api)
+  - [Registration API](#registration-api)
+- [Examples](#examples)
+  - [Higher Order Component](#higher-order-component)
+- [Utils](#utils)
 
 ---
 
@@ -34,6 +39,7 @@ yarn add fusion-plugin-font-loading
 ### Usage
 
 #### Configuration
+
 Consuming apps should define a `font-config.js` which a) provides data for @font-face generation, b) is used to derive the fallback font and styles that will be used by the `with-font-loading.js` HOC.
 
 ```js
@@ -82,9 +88,18 @@ export const fonts = {
 Based on the example configuration file above the following @font-face would typically be generated in <head>
 
 ```css
-@font-face {font-family: "Lato-Regular"; src: url("/_static/ca614426b50ca7d007056aa00954764b.woff2") format("woff2");}
-@font-face {font-family: "Lato-Bold"; src: url("/_static/ca104da8af9a2e0771e8fe2b31f8ec1e.woff2") format("woff2");}
-@font-face {font-family: "Lato-Thin"; src: url("/_static/03b64805a8cd2d53fadc5814445c2fb5.woff2") format("woff2");}
+@font-face {
+  font-family: 'Lato-Regular';
+  src: url('/_static/ca614426b50ca7d007056aa00954764b.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Lato-Bold';
+  src: url('/_static/ca104da8af9a2e0771e8fe2b31f8ec1e.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Lato-Thin';
+  src: url('/_static/03b64805a8cd2d53fadc5814445c2fb5.woff2') format('woff2');
+}
 ```
 
 ##### font loading
@@ -96,17 +111,19 @@ Based on the example configuration file above the following @font-face would typ
 Based on the sample config above (`preloadDepth` is set to 1), the HOC example above would yield the following values for `prop.$fontStyles`:
 
 while loading font:
+
 ```js
 {
-  fontFamily: 'Lato-Regular'
-  fontWeight: 'bold'
+  fontFamily: 'Lato-Regular';
+  fontWeight: 'bold';
 }
 ```
 
 when font is loaded:
+
 ```js
 {
-  fontFamily: 'Lato-Bold'
+  fontFamily: 'Lato-Bold';
 }
 ```
 
@@ -115,7 +132,7 @@ when font is loaded:
 `preloadDepth = 0`: Every font is preloaded, there are no fallback fonts. There is no FOFT or FOUT but there may be some FOIT
 Use this when jank-free font loading is more important than page load performance.
 
-`preloadDepth = 1`: Preload roman (non-stylized, e.g. `Lato`) fonts. Stylized fonts (e.g. `Lato-Bold`) will be lazily loaded and will fallback to preloaded font. During fallback period  the browser will apply the appropriate style to the roman font which will display a good approximation of the stylized font (FOFT) which is less jarring than falling back to a system font.
+`preloadDepth = 1`: Preload roman (non-stylized, e.g. `Lato`) fonts. Stylized fonts (e.g. `Lato-Bold`) will be lazily loaded and will fallback to preloaded font. During fallback period the browser will apply the appropriate style to the roman font which will display a good approximation of the stylized font (FOFT) which is less jarring than falling back to a system font.
 Use this when you want to balance performance with font-loading smoothness
 
 `preloadDepth = 2`: Don't preload any fonts. Lazily load all fonts. Lazily loading fonts will immediately fallback to the system font (FOUT).
@@ -127,17 +144,20 @@ Use this when page load performance is more important than font-load smoothness
 // src/main.js
 import App from 'fusion-core';
 import FontLoaderReactPlugin, {
-  FontLoaderReactConfigToken
+  FontLoaderReactConfigToken,
 } from 'fusion-plugin-font-loader-react';
 
 export default () => {
-  const app = new App(<div></div>);
+  const app = new App(<div />);
   // ...
-  app.register(FontLoaderReactConfigToken, {/*some config*/});
+  app.register(FontLoaderReactConfigToken, {
+    fonts,
+    preloadDepth,
+  });
   app.register(FontLoaderReact);
   // ...
   return app;
-}
+};
 
 // src/some-component.js
 import {withFontLoading} from 'fusion-plugin-font-loader-react';
@@ -152,6 +172,41 @@ const FancyLink1 = withFontLoading('Lato-Bold')(
 
 ---
 
+### API
+
+#### Registration API
+
+##### `FontLoaderReact`
+
+```js
+import FontLoaderReact from 'fusion-plugin-font-loader-react';
+```
+
+The Font Loader plugin for React. Adds font loading in the plugin middleware.
+
+##### `FontLoaderReactConfigToken`
+
+```js
+import {FontLoaderReactConfigToken} from 'fusion-plugin-font-loader-react';
+```
+
+Defines the font loader configuration.
+
+###### Types
+
+```js
+type FontLoaderReactConfigToken = {
+  fonts: {
+    [string]: FontType,
+  },
+  preloadDepth: number,
+};
+```
+
+---
+
+### Examples
+
 #### Higher Order Component
 
 ```js
@@ -159,6 +214,7 @@ import {withFontLoading} from 'fusion-plugin-font-loader-react';
 ```
 
 This repo also supplies a `with-font-loading.js` Higher Order Component which is used to:
+
 1. Load a specified font
 2. Temporarily assign a fallback font and styles to the wrapped component via `props.$fontStyles`
 3. When the font is loaded assign the true font to child component via `props.$fontStyles`
@@ -176,11 +232,11 @@ const FancyLink1 = hoc(
 This will lazy-load `Lato-Bold` and meanwhile assign a fallback font and styling to the element via `props.$fontStyles`.
 
 ```flow
-const hoc:HOC = withFontLoading(font: string)
+const hoc: HOC = withFontLoading((font: string));
 ```
 
-* `font: string` - The name of the font whose loading should be managed by the plugin
-* returns `hoc: Component => Component`
+- `font: string` - The name of the font whose loading should be managed by the plugin
+- returns `hoc: Component => Component`
 
 ---
 
@@ -191,12 +247,3 @@ const hoc:HOC = withFontLoading(font: string)
 Promise used by `with-font-loading.js` HOC to dynamically load specified font; calls `resolve` when load is complete.
 
 Uses `document.fonts.load` where available (chrome and firefox as of 10/17), otherwise uses a polyfill.
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Current documentation for this plugin is missing information and does not follow examples from other plugins. For example, I don't see any information about the expected shape of FontLoaderReactConfigToken, nor is there a registration section.

Rendered doc: https://github.com/fusionjs/fusion-plugin-font-loader-react/blob/00b08892ee54d4cf53b2b583a7e5b48887606da2/README.md

Fixes #97.