### PR TITLE
Fix preload state leak

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,15 +13,12 @@ import React from 'react';
 import {createPlugin, html, dangerouslySetHTML} from 'fusion-core';
 
 import FontProvider from './provider';
+import PreloadEngine from './preload-engine';
 import generateFallbackMap from './generate-fallback-map';
 import generatePreloadLinks from './generate-preload-links';
 import generateFontFaces from './generate-font-faces';
 import {FontLoaderReactConfigToken as ConfigToken} from './tokens';
 import type {PluginType} from './types.js';
-
-// keys are the actual fonts to preload (based on usage on the page), values are always true
-const fontsToPreload = {};
-let fallbackLookup;
 
 const plugin = createPlugin({
   deps: {
@@ -29,12 +26,13 @@ const plugin = createPlugin({
   },
   middleware: ({config}) => {
     const {fonts, preloadDepth} = config;
-    fallbackLookup = generateFallbackMap(fonts, preloadDepth);
+    const fallbackLookup = generateFallbackMap(fonts, preloadDepth);
+    const preloadEngine = new PreloadEngine(fallbackLookup);
 
     return (ctx, next) => {
       if (ctx.element) {
         ctx.element = (
-          <FontProvider getFontDetails={getFontDetails}>
+          <FontProvider getFontDetails={preloadEngine.getFontDetails}>
             {ctx.element}
           </FontProvider>
         );
@@ -46,7 +44,9 @@ const plugin = createPlugin({
             );
             ctx.template.head.push(html`</style>`);
             ctx.template.head.push(
-              dangerouslySetHTML(generatePreloadLinks(fontsToPreload, fonts))
+              dangerouslySetHTML(
+                generatePreloadLinks(preloadEngine.fontsToPreload, fonts)
+              )
             );
           }
         });
@@ -57,18 +57,3 @@ const plugin = createPlugin({
   },
 });
 export default (plugin: PluginType);
-
-/* Helper functions */
-function getFontDetails(name) {
-  const {name: fallbackName, styles = {}} = fallbackLookup[name] || {};
-  const result = {
-    name,
-    fallbackName,
-    styles,
-  };
-  if (__NODE__) {
-    // preload fallback, or if font has no fallback preload font itself
-    fontsToPreload[fallbackName || name] = true;
-  }
-  return result;
-}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,7 +13,7 @@ import React from 'react';
 import {createPlugin, html, dangerouslySetHTML} from 'fusion-core';
 
 import FontProvider from './provider';
-import PreloadEngine from './preload-engine';
+import PreloadSession from './preload-session';
 import generateFallbackMap from './generate-fallback-map';
 import generatePreloadLinks from './generate-preload-links';
 import generateFontFaces from './generate-font-faces';
@@ -27,12 +27,12 @@ const plugin = createPlugin({
   middleware: ({config}) => {
     const {fonts, preloadDepth} = config;
     const fallbackLookup = generateFallbackMap(fonts, preloadDepth);
-    const preloadEngine = new PreloadEngine(fallbackLookup);
+    const preloadSession = new PreloadSession(fallbackLookup);
 
     return (ctx, next) => {
       if (ctx.element) {
         ctx.element = (
-          <FontProvider getFontDetails={preloadEngine.getFontDetails}>
+          <FontProvider getFontDetails={preloadSession.getFontDetails}>
             {ctx.element}
           </FontProvider>
         );
@@ -45,7 +45,7 @@ const plugin = createPlugin({
             ctx.template.head.push(html`</style>`);
             ctx.template.head.push(
               dangerouslySetHTML(
-                generatePreloadLinks(preloadEngine.fontsToPreload, fonts)
+                generatePreloadLinks(preloadSession.fontsToPreload, fonts)
               )
             );
           }

--- a/src/preload-engine.js
+++ b/src/preload-engine.js
@@ -1,0 +1,31 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+class PreloadEngine {
+  constructor(fallbackLookup: FallbackLookup) {
+    // keys are the actual fonts to preload (based on usage on the page), values are always true
+    this.fontsToPreload = {};
+    this.fallbackLookup = fallbackLookup;
+  }
+
+  getFontDetails = name => {
+    const {name: fallbackName, styles = {}} = this.fallbackLookup[name] || {};
+    const result = {
+      name,
+      fallbackName,
+      styles,
+    };
+    if (__NODE__) {
+      // preload fallback, or if font has no fallback preload font itself
+      this.fontsToPreload[fallbackName || name] = true;
+    }
+    return result;
+  };
+}
+
+export default PreloadEngine;

--- a/src/preload-session.js
+++ b/src/preload-session.js
@@ -6,14 +6,24 @@
  * @flow
  */
 
+type FallbackLookup = {
+  [string]: {
+    name: string,
+    styles: mixed,
+  },
+};
+
 class PreloadSession {
+  fontsToPreload: {[string]: boolean};
+  fallbackLookup: FallbackLookup;
+
   constructor(fallbackLookup: FallbackLookup) {
     // keys are the actual fonts to preload (based on usage on the page), values are always true
     this.fontsToPreload = {};
     this.fallbackLookup = fallbackLookup;
   }
 
-  getFontDetails = name => {
+  getFontDetails = (name: string) => {
     const {name: fallbackName, styles = {}} = this.fallbackLookup[name] || {};
     const result = {
       name,

--- a/src/preload-session.js
+++ b/src/preload-session.js
@@ -6,7 +6,7 @@
  * @flow
  */
 
-class PreloadEngine {
+class PreloadSession {
   constructor(fallbackLookup: FallbackLookup) {
     // keys are the actual fonts to preload (based on usage on the page), values are always true
     this.fontsToPreload = {};
@@ -28,4 +28,4 @@ class PreloadEngine {
   };
 }
 
-export default PreloadEngine;
+export default PreloadSession;


### PR DESCRIPTION
I noticed the plugin was preloading fonts not based on what was rendered in the current request, but actually the set of all fonts that have been rendered by the server process in all subsequent requests. To minimize unnecessary preloads, this diff introduces a preload engine to keep track of the fonts that were rendered in the current request.