### PR TITLE
Add `font-display: fallback` to font faces

### DIFF
--- a/src/__tests__/fixtures/expected.js
+++ b/src/__tests__/fixtures/expected.js
@@ -32,7 +32,7 @@ export const fallbackLookup = {
 };
 
 export const fontFaces =
-  '\n@font-face {font-family: "Lato-Regular"; src: url("Lato-Regular.woff") format("woff")\n,url("Lato-Regular.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Bold"; src: url("Lato-Bold.woff") format("woff")\n,url("Lato-Bold.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Thin"; src: url("Lato-Thin.woff") format("woff")\n,url("Lato-Thin.woff2") format("woff2")\n;}';
+  '\n@font-face {font-family: "Lato-Regular"; font-display: \'fallback\', src: url("Lato-Regular.woff") format("woff")\n,url("Lato-Regular.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Bold"; font-display: \'fallback\', src: url("Lato-Bold.woff") format("woff")\n,url("Lato-Bold.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Thin"; font-display: \'fallback\', src: url("Lato-Thin.woff") format("woff")\n,url("Lato-Thin.woff2") format("woff2")\n;}';
 
 export const preloadLinks =
   '\n<link rel="preload" href="Lato-Regular.woff2" as="font" type="font/woff2" crossorigin>';

--- a/src/generate-font-faces.js
+++ b/src/generate-font-faces.js
@@ -12,7 +12,7 @@ export default function generateFontFaces(fontDictionary: {}) {
     const font = fontDictionary[fontName];
     if (font) {
       faces.push(
-        `@font-face {font-family: "${fontName}"; src: ${String(
+        `@font-face {font-family: "${fontName}"; font-display: 'fallback', src: ${String(
           asFontFaceSrc(font.urls)
         )};}`
       );


### PR DESCRIPTION
Resolves #131 

This allows developers to optionally skip withFontLoading HOC in favor of just adding fontFamily in styletron definition. It is a workaround for https://github.com/fusionjs/fusion-plugin-font-loader-react/issues/108, pending a refactor of the HOC API. 

Note: where font-display is not supported (currently Edge, Android plus older browsers) skipping the HOC *may* result in some old fashioned FOIC and FOUT, though this can be minimized by configuring for maximum preload (set `preloadDepth` to 0 in `src/font/config.js`) 