### PR TITLE
Fix font-display descriptor typo

### DIFF
--- a/src/__tests__/fixtures/expected.js
+++ b/src/__tests__/fixtures/expected.js
@@ -32,7 +32,7 @@ export const fallbackLookup = {
 };
 
 export const fontFaces =
-  '\n@font-face {font-family: "Lato-Regular"; font-display: \'fallback\', src: url("Lato-Regular.woff") format("woff")\n,url("Lato-Regular.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Bold"; font-display: \'fallback\', src: url("Lato-Bold.woff") format("woff")\n,url("Lato-Bold.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Thin"; font-display: \'fallback\', src: url("Lato-Thin.woff") format("woff")\n,url("Lato-Thin.woff2") format("woff2")\n;}';
+  '\n@font-face {font-family: "Lato-Regular"; font-display: fallback; src: url("Lato-Regular.woff") format("woff")\n,url("Lato-Regular.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Bold"; font-display: fallback; src: url("Lato-Bold.woff") format("woff")\n,url("Lato-Bold.woff2") format("woff2")\n;}\n@font-face {font-family: "Lato-Thin"; font-display: fallback; src: url("Lato-Thin.woff") format("woff")\n,url("Lato-Thin.woff2") format("woff2")\n;}';
 
 export const preloadLinks =
   '\n<link rel="preload" href="Lato-Regular.woff2" as="font" type="font/woff2" crossorigin>';

--- a/src/generate-font-faces.js
+++ b/src/generate-font-faces.js
@@ -12,7 +12,7 @@ export default function generateFontFaces(fontDictionary: {}) {
     const font = fontDictionary[fontName];
     if (font) {
       faces.push(
-        `@font-face {font-family: "${fontName}"; font-display: 'fallback', src: ${String(
+        `@font-face {font-family: "${fontName}"; font-display: fallback; src: ${String(
           asFontFaceSrc(font.urls)
         )};}`
       );


### PR DESCRIPTION
The comma is supposed to be a semi-colon. Additionally, the value
doesn't require surrounding quotes. The quotes are removed to conform
to convention.